### PR TITLE
LEAN-4434: RMI-040 - Implement the References UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/library",
-  "version": "1.3.13",
+  "version": "1.3.14-LEAN-4434.0",
   "repository": "github:Atypon-OpenSource/manuscripts-library",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/library",
-  "version": "1.3.14-LEAN-4434.0",
+  "version": "1.3.14",
   "repository": "github:Atypon-OpenSource/manuscripts-library",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/citation-transformer.ts
+++ b/src/citation-transformer.ts
@@ -39,7 +39,5 @@ export const transformBibliography = async (
   const cite = await Citation.Cite.async(data.trim())
   return cite.data.map((item: BibliographyItem) => ({
     ...item,
-    doi: item.DOI,
-    containerTitle: item['container-title'],
   }))
 }


### PR DESCRIPTION
This pull request modifies the `transformBibliography` function in `src/citation-transformer.ts` to simplify the returned object by removing unnecessary properties.

Key change:

* [`src/citation-transformer.ts`](diffhunk://#diff-cdfddf99244dae4c722ccf3da1dd3026778afed2414318a74c4639a19eb6a90cL42-L43): Removed the `doi` and `containerTitle` properties from the mapped bibliography items in the `transformBibliography` function, as they were deemed unnecessary.